### PR TITLE
Add User model with password hashing (M3)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,4 +30,7 @@ def create_app(config_class=Config):
     from app.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
 
+    # Import models so SQLAlchemy registers them
+    from app import models  # noqa: F401
+
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,24 @@
+"""Database models for PromptShare."""
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from app import db
+
+
+class User(db.Model):
+    """A registered user of PromptShare."""
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(20), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(256), nullable=False)
+
+    def set_password(self, password):
+        """Hash and store the user's password (with salt)."""
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        """Verify a password against the stored hash."""
+        return check_password_hash(self.password_hash, password)
+
+    def __repr__(self):
+        return f'<User {self.username}>'


### PR DESCRIPTION
Adds the User SQLAlchemy model with secure password hashing using werkzeug.security (scrypt + salt).

Closes #17
Closes #18

Tested in Python shell: created user, verified password hashing, confirmed wrong passwords are rejected, confirmed user persists in SQLite database.